### PR TITLE
impl new pull request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,4 +205,3 @@ add_dependencies(shm_talker shm_transport_generate_messages_cpp)
 add_executable(shm_listener test/shm_listener.cpp)
 target_link_libraries(shm_listener ${catkin_LIBRARIES} -lrt)
 add_dependencies(shm_listener shm_transport_generate_messages_cpp)
-

--- a/include/shm_subscriber.hpp
+++ b/include/shm_subscriber.hpp
@@ -17,46 +17,50 @@ namespace shm_transport {
   class SubscriberCallbackHelper {
     typedef void (*Func)(const boost::shared_ptr< const M > &);
 
-    private:
-      SubscriberCallbackHelper(const std::string &topic, Func fp)
-        : pshm_(NULL), topic_(topic), fp_(fp), sub_((ros::Subscriber *)NULL) {
-      }
+  private:
+    SubscriberCallbackHelper(const std::string &topic, Func fp)
+      : pshm_(NULL), topic_(topic), fp_(fp), sub_((ros::Subscriber *)NULL) {
 
-    public:
-      ~SubscriberCallbackHelper() {
-        if (pshm_) {
+    }
+
+  public:
+    ~SubscriberCallbackHelper() {
+      if (pshm_) {
           boost::atomic<uint32_t> *ref_ptr = pshm_->find_or_construct<boost::atomic<uint32_t> >("ref")(0);
           if (ref_ptr->fetch_sub(1, boost::memory_order_relaxed) == 1) {
-            boost::interprocess::shared_memory_object::remove(sub_->getTopic().c_str());
-            ROS_INFO("shm file <%s> removed\n", sub_->getTopic().c_str());
-          }
+              if(sub_) {
+                  boost::interprocess::shared_memory_object::remove(sub_->getTopic().c_str());
+                  //printf("subscriber: shm file <%s> removed\n", sub_->getTopic().c_str());
+                }
+            }
           delete pshm_;
         }
-      }
+    }
 
-      void callback(const std_msgs::UInt64::ConstPtr & actual_msg) {
-        if (!pshm_) {
+    void callback(const std_msgs::UInt64::ConstPtr & actual_msg) {
+      if (!pshm_) {   //a small trick. If suscriber runs first, it will not die due to these code.
           pshm_ = new boost::interprocess::managed_shared_memory(boost::interprocess::open_only, topic_.c_str());
           boost::atomic<uint32_t> *ref_ptr = pshm_->find_or_construct<boost::atomic<uint32_t> >("ref")(0);
           ref_ptr->fetch_add(1, boost::memory_order_relaxed);
         }
-        // FIXME this segment should be locked
-        uint32_t * ptr = (uint32_t *)pshm_->get_address_from_handle(actual_msg->data);
-        M msg;
-        ros::serialization::IStream in((uint8_t *)(ptr + 2), ptr[1]);
-        ros::serialization::deserialize(in, msg);
-        // FIXME is boost::atomic rely on x86?
-        if (reinterpret_cast< boost::atomic< uint32_t > * >(ptr)->fetch_sub(1, boost::memory_order_relaxed) == 1) {
+      // FIXME this segment should be locked
+      uint32_t * ptr = (uint32_t *)pshm_->get_address_from_handle(actual_msg->data);
+      M msg;
+      ros::serialization::IStream in((uint8_t *)(ptr + 2), ptr[1]);
+      ros::serialization::deserialize(in, msg);
+      // FIXME is boost::atomic rely on x86?
+      if (reinterpret_cast< boost::atomic< uint32_t > * >(ptr)->fetch_sub(1, boost::memory_order_relaxed) == 1) {
           pshm_->deallocate(ptr);
         }
-        fp_(boost::make_shared< M >(msg));
-      }
 
-    private:
-      boost::interprocess::managed_shared_memory * pshm_;
-      std::string topic_;
-      Func fp_;
-      boost::shared_ptr< ros::Subscriber > sub_;
+      fp_(boost::make_shared< M >(msg));
+    }
+
+  private:
+    boost::interprocess::managed_shared_memory * pshm_;
+    std::string topic_;
+    Func fp_;
+    boost::shared_ptr< ros::Subscriber > sub_;
 
     friend class Topic;
     friend class Subscriber<M>;
@@ -64,41 +68,59 @@ namespace shm_transport {
 
   template <class M>
   class Subscriber {
+  private:
+    Subscriber(const ros::Subscriber & sub_, SubscriberCallbackHelper< M > * phlp) {
+      impl_ = boost::make_shared<Impl>();
+
+      impl_->sub = boost::make_shared< ros::Subscriber >(sub_);
+      impl_->phlp = phlp;
+      impl_->phlp->sub_ = boost::make_shared< ros::Subscriber >(sub_);
+    }
+
+    class Impl {
     public:
-      Subscriber(const Subscriber & s) {
-        sub_ = s.sub_;
-        phlp_ = s.phlp_;
-      }
-    private:
-      Subscriber(const ros::Subscriber & sub, SubscriberCallbackHelper< M > * phlp) {
-        sub_ = boost::make_shared< ros::Subscriber >(sub);
-        phlp_ = phlp;
-        phlp_->sub_ = sub_;
+      Impl() {
       }
 
-    public:
-      ~Subscriber() {
-        if (phlp_)
-          delete phlp_;
-        if (sub_)
-          shutdown();
+      ~Impl() {
+        if (phlp) {
+            delete phlp;
+          }
+        if (sub) {
+            sub->shutdown();
+          }
       }
 
-      void shutdown() {
-        sub_->shutdown();
-      }
+      boost::shared_ptr< ros::Subscriber > sub;
+      SubscriberCallbackHelper< M > * phlp;
+    };
 
-      std::string getTopic() const {
-        return sub_->getTopic();
-      }
+    boost::shared_ptr<Impl> impl_;
 
-      uint32_t getNumPublishers() const {
-        return sub_->getNumPublishers();
-      }
+  public:
+    Subscriber() {
+    }
 
-    protected:
-      boost::shared_ptr< ros::Subscriber > sub_;
-      SubscriberCallbackHelper< M > * phlp_;
+    ~Subscriber() {
+    }
+
+    Subscriber(const Subscriber & s) {
+      impl_ = s.impl_;
+    }
+
+    void shutdown() {
+      impl_->sub->shutdown();
+    }
+
+    std::string getTopic() const {
+      return impl_->sub->getTopic();
+    }
+
+    uint32_t getNumPublishers() const {
+      return impl_->sub->getNumPublishers();
+    }
+
+  protected:
 
     friend class Topic;
   };

--- a/include/shm_topic.hpp
+++ b/include/shm_topic.hpp
@@ -12,32 +12,29 @@
 namespace shm_transport {
 
   class Topic {
-    public:
-      Topic(const ros::NodeHandle & parent) {
-        nh_ = boost::make_shared<ros::NodeHandle>(parent);
-      }
+  public:
+    Topic(const ros::NodeHandle & parent) {
+      nh_ = boost::make_shared<ros::NodeHandle>(parent);
+    }
 
-      ~Topic() {
-      }
+    ~Topic() {
+    }
 
-      template < class M >
-      Publisher advertise(const std::string & topic, uint32_t queue_size, uint32_t mem_size) {
-        ros::Publisher pub = nh_->advertise< std_msgs::UInt64 >(topic, queue_size);
-        boost::interprocess::managed_shared_memory * pshm = new boost::interprocess::managed_shared_memory(boost::interprocess::open_or_create, topic.c_str(), mem_size);
-        boost::atomic<uint32_t> *ref_ptr = pshm->find_or_construct<boost::atomic<uint32_t> >("ref")(0);
-        ref_ptr->fetch_add(1, boost::memory_order_relaxed);
-        return Publisher(pub, pshm);
-      }
+    template < class M >
+    Publisher advertise(const std::string & topic, uint32_t queue_size, uint32_t mem_size) {
+      ros::Publisher pub = nh_->advertise< std_msgs::UInt64 >(topic, queue_size);
+      return Publisher(pub, topic, mem_size);
+    }
 
-      template < class M >
-      Subscriber< M > subscribe(const std::string & topic, uint32_t queue_size, void(*fp)(const boost::shared_ptr< const M > &)) {
-        SubscriberCallbackHelper< M > * phlp = new SubscriberCallbackHelper< M >(topic, fp);
-        ros::Subscriber sub = nh_->subscribe(topic, queue_size, &SubscriberCallbackHelper< M >::callback, phlp);
-        return Subscriber< M >(sub, phlp);
-      }
+    template < class M >
+    Subscriber< M > subscribe(const std::string & topic, uint32_t queue_size, void(*fp)(const boost::shared_ptr< const M > &)) {
+      SubscriberCallbackHelper< M > * phlp = new SubscriberCallbackHelper< M >(topic, fp);
+      ros::Subscriber sub = nh_->subscribe(topic, queue_size, &SubscriberCallbackHelper< M >::callback, phlp);
+      return Subscriber< M >(sub, phlp);
+    }
 
-    private:
-      boost::shared_ptr< ros::NodeHandle > nh_;
+  private:
+    boost::shared_ptr< ros::NodeHandle > nh_;
   };
 
 }


### PR DESCRIPTION
BUGFIX TODO 1. Subscribe to the same topic in one procedure will be wrong 2. When a subscriber exit, there may be one message left in the shared memory space.

1. Due to the implemention of normal ROS subscriber, it will be something
wrong when subscribe to the same topic in one procedure, for the
publisher will think there is only one subscriber listen to the topic,
but actually there are two. Maybe we can open an issue on github ros_comm.

2. When a subscriber exit, the publisher may not know the
decreace of the number of subscribers, so it still publish
more message than exactly what is. Then the extra message
will be left in the shared memory space. If the space is not
that big or subscribers exit many times, it will throw bad_alloc exception.